### PR TITLE
Added the DFRobot_RTU library as a missing dependency.

### DIFF
--- a/DFRobot_RTU-master/LICENCE
+++ b/DFRobot_RTU-master/LICENCE
@@ -1,0 +1,7 @@
+Copyright 2010 DFRobot Co.Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/DFRobot_RTU-master/README.md
+++ b/DFRobot_RTU-master/README.md
@@ -1,0 +1,351 @@
+# DFRobot_RTU
+
+* [中文版](./README_CN.md)
+
+Modbus RTU library for Arduino. The supported modbus commands are as follows：<br>
+* 0x01: Read one or multiple coils register;
+* 0x02: Read one or multiple discrete inputs register;
+* 0x03: Read one or multiple holding register;
+* 0x04: Read one or multiple input register;
+* 0x05: Write a coils register;
+* 0x06: write a holding register;
+* 0x0F: Write multiple coils register;
+* 0x10: Write multiple holding register;
+
+![正反面svg效果图](https://github.com/Arya11111/DFRobot_MCP23017/blob/master/resources/images/SEN0245svg1.png)
+
+
+## Product Link（链接到英文商城）
+    
+   
+## Table of Contents
+
+* [Summary](#summary)
+* [Connected](#connected)
+* [Installation](#installation)
+* [Calibration](#calibration)
+* [Methods](#methods)
+* [Compatibility](#compatibility)
+* [History](#history)
+* [Credits](#credits)
+
+## Summary
+This is a modbus RTU libary  for Arduino by DFRobot.<br>
+
+## Connected
+Hardware conneted table 
+
+Sensor      |               MCU                 |
+------------ | :-------------------------------: |
+VCC          |                5V                 |
+GND          |                GND                |
+RX           |connected to the UART TX pin of MCU|
+TX           |connected to the UART RX pin of MCU|
+
+## Installation
+
+To use this library, first download the library file, paste it into the \Arduino\libraries directory, then open the examples folder and run the demo in the folder.
+
+## Methods
+
+```C++
+/**
+ * @brief DFRobot_RTU abstract class constructor. Construct serial port.
+ * @param s:  The class pointer object of Abstract class， here you can fill in the pointer to the serial port object.
+ * @param dePin: RS485 flow control, pull low to receive, pull high to send.
+ */
+DFRobot_RTU(Stream *s,int dePin);
+DFRobot_RTU(Stream *s);
+~DFRobot_RTU()
+
+/**
+ * @brief Set receive timeout time, unit ms.
+ * @param timeout:  receive timeout time, unit ms, default 100mss.
+ */
+void setTimeoutTimeMs(uint32_t timeout = 100);
+
+/**
+ * @brief Read a coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @return Return the value of the coils register value.
+ * @n      true: The value of the coils register value is 1.
+ * @n      false: The value of the coils register value is 0.
+ */
+  bool readCoilsRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief Read a discrete input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Discrete input register address.
+ * @return Return the value of the discrete input register.
+ */
+uint16_t readDiscreteInputsRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief Read a holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @return Return the value of the holding register value.
+ */
+uint16_t readHoldingRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief Read a input Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: input register address.
+ * @return Return the value of the input register value.
+ */
+  uint16_t readInputRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief Write a coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param flag: The value of the register value which will be write, 0 ro 1.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, bool flag);
+  
+/**
+ * @brief Write a holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t val);
+
+/**
+ * @brief Read multiple coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param regNum: Number of coils Register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size of data.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+
+/**
+ * @brief Read multiple discrete inputs register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Discrete inputs register. address.
+ * @param regNum: Number of coils Register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+uint8_t readDiscreteInputsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+
+/**
+ * @brief Read multiple Holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+uint8_t readHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief Read multiple Input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Input register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readInputRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief Read multiple Holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+
+/**
+ * @brief Read multiple Input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Input register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t DFRobot_RTU::readInputRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t size)
+
+/**
+ * @brief Write multiple coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param regNum: Numbers of Coils register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, void *data, uint16_t size);
+
+/**
+ * @brief Write multiple Holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief Write multiple Holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @param data: Storage register worth pointer.
+ * @param regNum: Number of coils Register..
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+```
+
+## Compatibility
+
+MCU                | SoftwareSerial | HardwareSerial |
+------------------ | :----------: | :----------: |
+Arduino Uno        |      √       |      X       |
+Mega2560           |      √       |      √       |
+Leonardo           |      √       |      √       |
+ESP32              |      X       |      √       |
+ESP8266            |      √       |      X       |
+micro:bit          |      X       |      X       |
+FireBeetle M0      |      X       |      √       |
+raspberry          |      X       |      √       |
+
+## History
+
+- Data 2021-07-17
+- Version V1.0
+
+## Credits
+
+Written by(xue.peng@dfrobot.com), 2021. (Welcome to our [website](https://www.dfrobot.com/))
+
+
+
+
+

--- a/DFRobot_RTU-master/README_CN.md
+++ b/DFRobot_RTU-master/README_CN.md
@@ -1,0 +1,324 @@
+# DFRobot_RTU
+
+* [English Version](./README.md)
+
+这是一个基于Modbus RTU协议的Arduino modbus库，它支持以下几种modbus协议命令：<br>
+* 0x01: 读一个或多个线圈寄存器；
+* 0x02: 读一个或多个离散输入寄存器；
+* 0x03: 读一个或多个保持寄存器；
+* 0x04: 读一个或多个输入寄存器；
+* 0x05: 写单个线圈寄存器；
+* 0x06: 写单个保持寄存器；
+* 0x0F: 写多个线圈寄存器；
+* 0x10: 写多个保持寄存器；
+
+![正反面svg效果图](https://github.com/Arya11111/DFRobot_MCP23017/blob/master/resources/images/SEN0245svg1.png)
+
+
+## Product Link（链接到英文商城）
+    
+   
+## Table of Contents
+
+* [Summary](#summary)
+* [Connected](#connected)
+* [Installation](#installation)
+* [Calibration](#calibration)
+* [Methods](#methods)
+* [Compatibility](#compatibility)
+* [History](#history)
+* [Credits](#credits)
+
+## Summary
+这是DFRobot基于modbus RTU协议为Arduino平台移植的modbus库。<br>
+
+## Connected
+Hardware conneted table 
+
+ Sensor      |               MCU                 |
+------------ | :-------------------------------: |
+VCC          |                5V                 |
+GND          |                GND                |
+RX           |connected to the UART TX pin of MCU|
+TX           |connected to the UART RX pin of MCU|
+
+## Installation
+
+To use this library, first download the library file, paste it into the \Arduino\libraries directory, then open the examples folder and run the demo in the folder.
+
+## Methods
+
+```C++
+/**
+ * @brief DFRobot_RTU构造函数. 传递串口指针.
+ * @param s:  串口抽象类指针。
+ * @param dePin RS485流控引脚,拉低接收，拉高发送
+ */
+DFRobot_RTU(Stream *s,int dePin);
+DFRobot_RTU(Stream *s);
+~DFRobot_RTU()
+
+/**
+ * @brief 设置串口接收超时时间，单位ms.
+ * @param timeout:  串口接收超时时间参数，单位ms，默认100ms
+ */
+void setTimeoutTimeMs(uint32_t timeout = 100);
+
+/**
+ * @brief 读取线圈寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 线圈寄存器地址.
+ * @return 返回线圈寄存器的值。
+ * @n      true: 线圈寄存器的值为1
+ * @n      false: 线圈寄存器的值为0
+ */
+  bool readCoilsRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief 读取离散输入寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 离散输入寄存器地址.
+ * @return 返回离散输入寄存器的值。
+ */
+uint16_t readDiscreteInputsRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief 读取保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 保持寄存器地址.
+ * @return 返回保持寄存器的值。
+ */
+uint16_t readHoldingRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief 读取输入寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 输入寄存器地址.
+ * @return 返回输入寄存器的值。
+ */
+  uint16_t readInputRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief 写单个线圈寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 线圈寄存器地址.
+ * @param flag: 要写入的线圈寄存器的值,0 或 1。
+ * @return 返回写线圈寄存起的值, 0 或 1。
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, bool flag);
+  
+/**
+ * @brief 写单个保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 保持寄存器地址.
+ * @param val: 要写入的保持寄存器的值。
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t val);
+
+/**
+ * @brief 读多个线圈寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读线圈寄存器的起始地址.
+ * @param regNum: 线圈寄存器的个数
+ * @param data: 存储要读取的数据的指针.
+ * @param size: 要读取的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+uint8_t readCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+
+/**
+ * @brief 读多个离散输入寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读离散输入寄存器的起始地址.
+ * @param regNum: 离散寄存器的个数
+ * @param data: 存储要读取的数据的指针.
+ * @param size: 要读取的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+uint8_t readDiscreteInputsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+
+/**
+ * @brief 读多个保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读保持寄存器的起始地址.
+ * @param data: 存储要读取的数据的指针.
+ * @param size: 要读取的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+uint8_t readHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+
+/**
+ * @brief 读多个输入寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读输入寄存器的起始地址.
+ * @param data: 存储要读取的数据的指针.
+ * @param size: 要读取的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+  uint8_t readInputRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief 读多个保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读保持寄存器的起始地址.
+ * @param data: 存储要读取的数据的指针.
+ * @param regNum: 表示要读取的寄存器的个数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+  uint8_t readHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+
+  /**
+ * @brief 读多个输入寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 读输入寄存器的起始地址.
+ * @param data: 存储要读取的数据的指针.
+ * @param size: 要读取的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+  uint8_t readInputRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t size);
+
+/**
+ * @brief 写多个线圈寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 写线圈寄存器的起始地址.
+ * @param regNum: 线圈寄存器的个数.
+ * @param data: 存储要写入的数据的指针.
+ * @param size: 要写入的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, void *data, uint16_t size);
+
+/**
+ * @brief 写多个保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 写保持寄存器的起始地址.
+ * @param data: 存储要写入的数据的指针.
+ * @param size: 要写入的字节数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief 写多个保持寄存器的值。
+ * @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+ * @param reg: 写保持寄存器的起始地址.
+ * @param data: 存储要写入的数据的指针.
+ * @param regNum: 表示要读取的寄存器的个数.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+ * @n      9 or eRTU_RECV_ERROR:  接收包错误.
+ * @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+ * @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+ */
+  uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+```
+
+## Compatibility
+
+MCU                | SoftwareSerial | HardwareSerial |
+------------------ | :----------: | :----------: |
+Arduino Uno        |      √       |      X       |
+Mega2560           |      √       |      √       |
+Leonardo           |      √       |      √       |
+ESP32              |      X       |      √       |
+ESP8266            |      √       |      X       |
+micro:bit          |      X       |      X       |
+FireBeetle M0      |      X       |      √       |
+raspberry          |      X       |      √       |
+
+## History
+
+- Data 2021-07-17
+- Version V1.0
+
+## Credits
+
+Written by(xue.peng@dfrobot.com), 2021. (Welcome to our [website](https://www.dfrobot.com/))

--- a/DFRobot_RTU-master/examples/modifyModbusID/modifyModbusID.ino
+++ b/DFRobot_RTU-master/examples/modifyModbusID/modifyModbusID.ino
@@ -1,0 +1,73 @@
+/*!
+ * @file modifyModbusID.ino
+ * @brief 修改modbus从机的设备ID。每个modbus从机都有唯一识别的设备ID号，范围0x0000~0x00F7(0~247),修改设备ID有2种方式：
+ * @n 1: 不知道设备的ID地址，可以通过广播地址0x00修改从机的ID地址，此命令会将总线上所有的从机的地址都修改为设置的ID（用0x00修改地址时，总线上最好只接一个设备）
+ * @n 2: 知道设备的ID地址，直接用ID修改
+ * @n note：运行此demo必须知道设备的串口配置(波特率，数据位，校验位，停止位)
+ * @n connected table
+ * ---------------------------------------------------------------------------------------------------------------
+ * sensor pin |             MCU                | Leonardo/Mega2560/M0 |    UNO    | ESP8266 | ESP32 |  microbit  |
+ *     VCC    |            3.3V/5V             |        VCC           |    VCC    |   VCC   |  VCC  |     X      |
+ *     GND    |              GND               |        GND           |    GND    |   GND   |  GND  |     X      |
+ *     RX     |              TX                |     Serial1 RX1      |     5     |5/D6(TX) |  D2   |     X      |
+ *     TX     |              RX                |     Serial1 TX1      |     4     |4/D7(RX) |  D3   |     X      |
+ * ---------------------------------------------------------------------------------------------------------------
+ *
+ *
+ * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+ * @licence     The MIT License (MIT)
+ * @author [Arya](xue.peng@dfrobot.com)
+ * @version  V1.0
+ * @date  2021-07-16
+ * @https://github.com/DFRobot/DFRobot_RTU
+ */
+#include "DFRobot_RTU.h"
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+#include <SoftwareSerial.h>
+#endif
+
+#define DEVICE_ID_REG   0x02
+
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+  SoftwareSerial mySerial(/*rx =*/4, /*tx =*/5);
+  DFRobot_RTU modbus(/*s =*/&mySerial);
+#else
+  DFRobot_RTU modbus(/*s =*/&Serial1);
+#endif
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial){                                                     //Waiting for USB Serial COM port to open.
+  }
+
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+    mySerial.begin(9600);
+#elif defined(ESP32)
+  Serial1.begin(9600, SERIAL_8N1, /*rx =*/D3, /*tx =*/D2);
+#else
+  Serial1.begin(9600);
+#endif
+  delay(1000);
+  
+  //方法1：通过广播地址0x00将modbus从机的地址设置为0x10
+  modbus.writeHoldingRegister(/*id =*/0x00, /*reg =*/DEVICE_ID_REG, /*val =*/0x10);
+  delay(1000);
+  uint16_t ret = modbus.readHoldingRegister(0x10, DEVICE_ID_REG);
+  if(ret == 0x10){
+      Serial.print("new ID1 is 0x");
+      Serial.println(ret, HEX);
+      //方法2：已知从机的地址为0x10，将其修改为0x20
+      modbus.writeHoldingRegister(/*id =*/0x00, /*reg =*/DEVICE_ID_REG, /*val =*/0x20);
+      delay(1000);
+      ret = modbus.readHoldingRegister(0x20, DEVICE_ID_REG);
+      Serial.print("new ID2 is 0x");
+      Serial.println(ret, HEX);
+  }
+
+}
+
+void loop() {
+  
+}
+
+

--- a/DFRobot_RTU-master/examples/scanModbusID/scanModbusID.ino
+++ b/DFRobot_RTU-master/examples/scanModbusID/scanModbusID.ino
@@ -1,0 +1,77 @@
+/*!
+ * @file scanModbusID.ino
+ * @brief 扫描modbus总线上，所有串口配置为9600波特率，8位数据位，无校验位，1位停止位的modbus从机的地址。
+ * @n modbus从机设备地址范围为1~247(0x01~0xF7),0为广播地址，所有modbus从机接受到广播包
+ * @n 都会处理，但不会响应。
+ * @n 一个modbus主机可以连多个modbus从机，在运行此demo之前，必须知道modbus从机的波特率，数据位，校
+ * @n 验位，停止位等串口配置。
+ * @n connected table
+ * ---------------------------------------------------------------------------------------------------------------
+ * sensor pin |             MCU                | Leonardo/Mega2560/M0 |    UNO    | ESP8266 | ESP32 |  microbit  |
+ *     VCC    |            3.3V/5V             |        VCC           |    VCC    |   VCC   |  VCC  |     X      |
+ *     GND    |              GND               |        GND           |    GND    |   GND   |  GND  |     X      |
+ *     RX     |              TX                |     Serial1 RX1      |     5     |5/D6(TX) |  D2   |     X      |
+ *     TX     |              RX                |     Serial1 TX1      |     4     |4/D7(RX) |  D3   |     X      |
+ * ---------------------------------------------------------------------------------------------------------------
+ * @note: 不支持UNO，Microbit，ESP8266
+ *
+ * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+ * @licence     The MIT License (MIT)
+ * @author [Arya](xue.peng@dfrobot.com)
+ * @version  V1.0
+ * @date  2021-07-16
+ * @https://github.com/DFRobot/DFRobot_RTU
+ */
+#include "DFRobot_RTU.h"
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+#include <SoftwareSerial.h>
+#endif
+
+#define DEVICE_ID_REG   0x02
+
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+  SoftwareSerial mySerial(/*rx =*/4, /*tx =*/5);
+  DFRobot_RTU modbus(/*s =*/&mySerial);
+#else
+  DFRobot_RTU modbus(/*s =*/&Serial1);
+#endif
+
+void setup() {
+  Serial.begin(115200);
+  while(!Serial){                                                     //Waiting for USB Serial COM port to open.
+  }
+
+#if defined(ARDUINO_AVR_UNO)||defined(ESP8266)
+    mySerial.begin(9600);
+#elif defined(ESP32)
+  Serial1.begin(9600, SERIAL_8N1, /*rx =*/3, /*tx =*/1);
+#else
+  Serial1.begin(9600);
+#endif
+  delay(1000);
+}
+
+void loop() {
+  uint8_t modbusID;
+  uint16_t ret = 0;
+  int nDevices;
+  Serial.println("Scanning...");
+  nDevices = 0;
+  for(modbusID = 1; modbusID < 248; modbusID++){
+      ret = modbus.readHoldingRegister(modbusID, DEVICE_ID_REG);
+      if(ret == modbusID){
+          Serial.print("modbus device found at address 0x");
+          if(modbusID < 16){ 
+              Serial.print("0");
+          }
+          Serial.print(modbusID,HEX);
+          Serial.println("  !");
+          nDevices++;
+      }
+  }
+  if(nDevices == 0)
+    Serial.println("No modbus devices found\n");
+  else
+    Serial.println("done\n");
+  delay(1000);           // wait 1 seconds for next scan
+}

--- a/DFRobot_RTU-master/keywords.txt
+++ b/DFRobot_RTU-master/keywords.txt
@@ -1,0 +1,50 @@
+#######################################
+# Syntax Map For DFRobot_SCT80S16B
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+DFRobot_RTU	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+
+readCoilsRegisterBit	KEYWORD2
+readDiscreteInputsRegisterBit	KEYWORD2
+writeCoilsRegister	KEYWORD2
+readCoilsRegister	KEYWORD2
+readDiscreteInputsRegister	KEYWORD2
+readHoldingRegister	KEYWORD2
+writeHoldingRegister	KEYWORD2
+
+
+
+#######################################
+# Instances (KEYWORD2)
+#######################################
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+eRTU_EXCEPTION_ILLEGAL_FUNCTION	LITERAL1
+eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS	LITERAL1
+eRTU_EXCEPTION_ILLEGAL_DATA_VALUE	LITERAL1
+eRTU_EXCEPTION_SLAVE_FAILURE	LITERAL1
+eRTU_EXCEPTION_CRC_ERROR	LITERAL1
+eRTU_RECV_ERROR	LITERAL1
+eRTU_MEMORY_ERROR	LITERAL1
+eRTU_ID_ERROR	LITERAL1
+eRtuStatusExceptionCode_t	LITERAL1
+eCMD_READ_COILS	LITERAL1
+eCMD_READ_DISCRETE	LITERAL1
+eCMD_READ_HOLDING	LITERAL1
+eCMD_WRITE_COILS	LITERAL1
+eCMD_WRITE_HOLDING	LITERAL1
+eCMD_WRITE_MULTI_COILS	LITERAL1
+eCMD_WRITE_MULTI_HOLDING	LITERAL1
+eFunctionCommand_t	LITERAL1
+RTU_BROADCAST_ADDRESS	LITERAL1

--- a/DFRobot_RTU-master/library.properties
+++ b/DFRobot_RTU-master/library.properties
@@ -1,0 +1,9 @@
+name=DFRobot_RTU
+version=1.0.3
+author=Arya DFRobot
+maintainer=DFRobot <www.dfrobot.com>
+sentence=Modbus RTU library for Arduino.
+paragraph=A library to use an Arduino as master to control and communicate via modbus protocol.
+category=Communication
+url=https://github.com/DFRobot/DFRobot_RTU
+architectures=*

--- a/DFRobot_RTU-master/python/raspberrypi/DFRobot_RTU.py
+++ b/DFRobot_RTU-master/python/raspberrypi/DFRobot_RTU.py
@@ -1,0 +1,541 @@
+# -*- coding:utf-8 -*-
+
+'''
+  @file DFRobot_RTU.py
+  @brief Modbus RTU libary for Arduino. 
+  
+  @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+  @licence     The MIT License (MIT)
+  @author [Arya](xue.peng@dfrobot.com)
+  @version  V1.0
+  @date  2021-07-16
+  @https://github.com/DFRobot/DFRobot_RTU
+'''
+import sys
+import serial
+import time
+
+class DFRobot_RTU(object):
+  
+  _packet_header = {"id": 0, "cmd": 1, "cs": 0}
+  
+  '''Enum constant'''
+  eRTU_EXCEPTION_ILLEGAL_FUNCTION     = 0x01
+  eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS = 0x02
+  eRTU_EXCEPTION_ILLEGAL_DATA_VALUE   = 0x03
+  eRTU_EXCEPTION_SLAVE_FAILURE        = 0x04
+  eRTU_EXCEPTION_CRC_ERROR            = 0x08
+  eRTU_RECV_ERROR                     = 0x09
+  eRTU_MEMORY_ERROR                   = 0x0A
+  eRTU_ID_ERROR                       = 0x0B
+  
+  eCMD_READ_COILS           = 0x01
+  eCMD_READ_DISCRETE        = 0x02
+  eCMD_READ_HOLDING         = 0x03
+  eCMD_READ_INPUT           = 0x04
+  eCMD_WRITE_COILS          = 0x05
+  eCMD_WRITE_HOLDING        = 0x06
+  eCMD_WRITE_MULTI_COILS    = 0x0F
+  eCMD_WRITE_MULTI_HOLDING  = 0x10
+
+  def __init__(self, baud, bits, parity, stopbit):
+    '''
+      @brief Serial initialization.
+      @param baud:  The UART baudrate of raspberry pi
+      @param bits:  The UART data bits of raspberry pi
+      @param parity:  The UART parity bits of raspberry pi
+      @param stopbit:  The UART stopbit bits of raspberry pi.
+    '''
+    self._ser = serial.Serial("/dev/ttyAMA0",baud, bits, parity, stopbit)
+    self._timeout = 0.1 #0.1s
+  
+  def set_timout_time_s(self, timeout = 0.1):
+    '''
+      @brief Set receive timeout time, unit s.
+      @param timeout:  receive timeout time, unit s, default 0.1s.
+    '''
+    self._timeout = timeout
+
+  def read_coils_register(self, id, reg):
+    '''
+      @brief Read a coils Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Coils register address.
+      @return Return the value of the coils register value.
+      @n      True: The value of the coils register value is 1.
+      @n      False: The value of the coils register value is 0.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), 0x00, 0x01]
+    val = False
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return 0
+    l = self._packed(id, self.eCMD_READ_COILS, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_COILS,1)
+    if (l[0] == 0) and len(l) == 7:
+      if (l[4] & 0x01) != 0:
+          val = True
+    return val
+      
+  def read_discrete_inputs_register(self, id, reg):
+    '''
+      @brief Read a discrete input register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Discrete input register address.
+      @return Return the value of the discrete input register value.
+      @n      True: The value of the discrete input register value is 1.
+      @n      False: The value of the discrete input register value is 0.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), 0x00, 0x01]
+    val = False
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return 0
+    l = self._packed(id, self.eCMD_READ_DISCRETE, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_DISCRETE,1)
+    if (l[0] == 0) and len(l) == 7:
+      if (l[4] & 0x01) != 0:
+          val = True
+    return val
+      
+  def read_holding_register(self, id, reg):
+    '''
+      @brief Read a holding Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Holding register address.
+      @return Return the value of the holding register value.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), 0x00, 0x01]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return 0
+    l = self._packed(id, self.eCMD_READ_HOLDING, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_HOLDING,2)
+    if (l[0] == 0) and len(l) == 8:
+      l[0] = ((l[4] << 8) | l[5]) & 0xFFFF
+    else:
+      l[0] = 0
+    return l[0]
+
+  def read_input_register(self, id, reg):
+    '''
+      @brief Read a input Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Input register address.
+      @return Return the value of the holding register value.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), 0x00, 0x01]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return 0
+    l = self._packed(id, self.eCMD_READ_INPUT, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_INPUT,2)
+    if (l[0] == 0) and len(l) == 8:
+      l[0] = ((l[4] << 8) | l[5]) & 0xFFFF
+    else:
+      l[0] = 0
+    return l[0]
+      
+  def write_coils_register(self, id, reg, flag):
+    '''
+      @brief Write a coils Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Coils register address.
+      @param flag: The value of the register value which will be write, 0 ro 1.
+      @return Exception code:
+      @n      0 : sucess.
+      @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n      10 or eRTU_MEMORY_ERROR: Memory error.
+      @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+    '''
+    val = 0x0000
+    re = True
+    if flag:
+      val = 0xFF00
+      re = False
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (val >> 8)&0xFF, (val & 0xFF)]
+    if(id > 0xF7):
+      print("device addr error.")
+      return 0
+    l = self._packed(id, self.eCMD_WRITE_COILS, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_WRITE_COILS,reg)
+    return l[0]
+      
+
+  def write_holding_register(self, id, reg, val):
+    '''
+      @brief Write a holding register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Holding register address.
+      @param val: The value of the register value which will be write.
+      @return Exception code:
+      @n      0 : sucess.
+      @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n      10 or eRTU_MEMORY_ERROR: Memory error.
+      @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (val >> 8)&0xFF, (val & 0xFF)]
+    val = 0
+    if(id > 0xF7):
+      print("device addr error.")
+      return 0
+    l = self._packed(id, self.eCMD_WRITE_HOLDING, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_WRITE_HOLDING,reg)
+    return l[0]
+      
+  def read_coils_registers(self, id, reg, reg_num):
+    '''
+      @brief Read multiple coils Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Read the start address of the coil register.
+      @param reg_num: Number of coils Register.
+      @return list: format as follow:
+      @n      list[0]: Exception code:
+      @n               0 : sucess.
+      @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n               10 or eRTU_MEMORY_ERROR: Memory error.
+      @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+      @n      list[1:]: The value of the coil register list.
+    '''
+    length = reg_num // 8
+    mod = reg_num % 8
+    if mod:
+      length += 1
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (reg_num >> 8) & 0xFF, reg_num & 0xFF]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return [self.eRTU_ID_ERROR]
+    l = self._packed(id, self.eCMD_READ_COILS, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_COILS,length)
+    if ((l[0] == 0) and (len(l) == (5+length+1))):
+      la = [l[0]] + l[4: len(l)-2]
+      return la
+    return [l[0]]
+    
+  def read_discrete_inputs_registers(self, id, reg, reg_num):
+    '''
+      @brief Read multiple discrete inputs register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Read the start address of the discrete inputs register.
+      @param reg_num: Number of coils Register.
+      @return list: format as follow:
+      @n      list[0]: Exception code:
+      @n               0 : sucess.
+      @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n               10 or eRTU_MEMORY_ERROR: Memory error.
+      @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+      @n      list[1:]: The value list of the discrete inputs register.
+    '''
+    length = reg_num // 8
+    mod = reg_num % 8
+    if mod:
+      length += 1
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (reg_num >> 8) & 0xFF, reg_num & 0xFF]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return [self.eRTU_ID_ERROR]
+    l = self._packed(id, self.eCMD_READ_DISCRETE, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_DISCRETE,length)
+    if ((l[0] == 0) and (len(l) == (5+length+1))):
+      la = [l[0]] + l[4: len(l)-2]
+      return la
+    return [l[0]]
+    
+  def read_holding_registers(self, id, reg, size):
+    '''
+      @brief Read multiple holding register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Read the start address of the holding register.
+      @param size: Number of read holding register.
+      @return list: format as follow:
+      @n      list[0]: Exception code:
+      @n               0 : sucess.
+      @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n               10 or eRTU_MEMORY_ERROR: Memory error.
+      @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+      @n      list[1:]: The value list of the holding register.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (size >> 8) & 0xFF, size & 0xFF]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return [self.eRTU_ID_ERROR]
+    l = self._packed(id, self.eCMD_READ_HOLDING, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_HOLDING,size*2)
+    #lin = ['%02X' % i for i in l]
+    #print(" ".join(lin))
+    if (l[0] == 0) and (len(l) == (5+size*2+1)):
+      la = [l[0]] + l[4: len(l)-2]
+      return la
+    return [l[0]]
+
+  def read_input_registers(self, id, reg, size):
+    '''
+      @brief Read multiple input register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Read the start address of the input register.
+      @param size: Number of read input register.
+      @return list: format as follow:
+      @n      list[0]: Exception code:
+      @n               0 : sucess.
+      @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n               10 or eRTU_MEMORY_ERROR: Memory error.
+      @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+      @n      list[1:]: The value list of the input register.
+    '''
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), (size >> 8) & 0xFF, size & 0xFF]
+    if (id < 1) or (id > 0xF7):
+      print("device addr error.(1~247) %d"%id)
+      return [self.eRTU_ID_ERROR]
+    l = self._packed(id, self.eCMD_READ_INPUT, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_READ_INPUT,size*2)
+    #lin = ['%02X' % i for i in l]
+    #print(" ".join(lin))
+    if (l[0] == 0) and (len(l) == (5+size*2+1)):
+      la = [l[0]] + l[4: len(l)-2]
+      return la
+    return [l[0]]
+    
+  def write_coils_registers(self, id, reg, reg_num, data):
+    '''
+      @brief Write multiple coils Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Write the start address of the coils register.
+      @param reg_num: Number of coils Register.
+      @param data: The list of storage coils Registers' value which will be write.
+      @return Exception code:
+      @n      0 : sucess.
+      @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n      10 or eRTU_MEMORY_ERROR: Memory error.
+      @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+    '''
+    length = reg_num // 8
+    mod = reg_num % 8
+    if mod:
+      length += 1
+    if len(data) < length:
+      return [self.eRTU_EXCEPTION_ILLEGAL_DATA_VALUE]
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), ((reg_num >> 8) & 0xFF), (reg_num & 0xFF), length] + data
+    if(id > 0xF7):
+      print("device addr error.")
+      return 0
+    l = self._packed(id, self.eCMD_WRITE_MULTI_COILS, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_WRITE_MULTI_COILS,reg)
+    if (l[0] == 0) and len(l) == 9:
+      val = ((l[5] << 8) | l[6]) & 0xFFFF
+    return l[0]
+      
+  def write_holding_registers(self, id, reg, data):
+    '''
+      @brief Write multiple holding Register.
+      @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+      @n          but will not answer.
+      @param reg: Write the start address of the holding register.
+      @param data: The list of storage holding Registers' value which will be write.
+      @return Exception code:
+      @n      0 : sucess.
+      @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+      @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+      @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+      @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+      @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+      @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+      @n      10 or eRTU_MEMORY_ERROR: Memory error.
+      @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+    '''
+    size = len(data) >> 1
+    l = [(reg >> 8)&0xFF, (reg & 0xFF), ((size >> 8) & 0xFF), (size & 0xFF), size*2] + data
+    if(id > 0xF7):
+      print("device addr error.")
+      return 0
+    l = self._packed(id, self.eCMD_WRITE_MULTI_HOLDING, l)
+    self._send_package(l)
+    l = self.recv_and_parse_package(id, self.eCMD_WRITE_MULTI_HOLDING,reg)
+    if (l[0] == 0) and len(l) == 9:
+      val = ((l[5] << 8) | l[6]) & 0xFFFF
+    return l[0]
+      
+  def _calculate_crc(self, data):
+    crc = 0xFFFF
+    length = len(data)
+    #print("len=%d"%length)
+    pos = 0
+    while pos < length:
+      crc ^= (data[pos] | 0x0000)
+      #print("pos=%d, %02x"%(pos,data[pos]))
+      i = 8;
+      while i != 0:
+        if (crc & 0x0001) != 0:
+          crc = (crc >> 1)&0xFFFF
+          crc ^= 0xA001
+        else:
+          crc = (crc >> 1)&0xFFFF
+        i -= 1
+      pos += 1
+    crc = (((crc & 0x00FF) << 8) | ((crc & 0xFF00) >> 8)) & 0xFFFF
+    #print("crc=%x"%crc)
+    return crc
+
+  def _clear_recv_buffer(self):
+    remain = self._ser.inWaiting()
+    while remain:
+      self._ser.read(remain)
+      remain = self._ser.inWaiting()
+
+  def _packed(self, id, cmd, l):
+    length = 4+len(l)
+    #print(len(l))
+    package = [0]*length
+    package[0] = id
+    package[1] = cmd
+    package[2:length-2] = l
+    #lin = ['%02X' % i for i in package]
+    #print(" ".join(lin))
+
+    crc = self._calculate_crc(package[:len(package)-2])
+    package[length-2] = (crc >> 8) & 0xFF
+    package[length-1] = crc & 0xFF
+    
+    #lin = ['%02X' % i for i in package]
+    #print(" ".join(lin))
+    return package;
+
+  def _send_package(self, l):
+    self._clear_recv_buffer()
+    if len(l):
+      self._ser.write(l)
+      time.sleep(self._timeout)
+
+  def recv_and_parse_package(self, id, cmd, val):
+    package = [self.eRTU_ID_ERROR]
+    if id == 0:
+      return [0]
+    if (id < 1) or (id > 0xF7):
+      return package
+    head = [0]*4
+    index = 0
+    t = time.time()
+    remain = 0
+    while remain < 4:
+      if self._ser.inWaiting():
+        data = self._ser.read(1)
+        try: 
+          head[index] = ord(data)
+        except:
+          head[index] = data
+        #print("%d = %02X"%(index, head[index]))
+        index += 1
+        if (index == 1) and (head[0] != id):
+          index = 0
+        elif (index == 2) and ((head[1] & 0x7F) != cmd):
+          index = 0
+        remain = index
+        t = time.time()
+      if time.time() - t > self._timeout:
+        #print("time out.")
+        return [self.eRTU_RECV_ERROR]
+      if(index == 4):
+        if head[1] & 0x80:
+          index = 5
+        else:
+          if head[1] < 5:
+            if head[2] != (val & 0xFF):
+              index = 0
+              remain = 0
+            else:
+              index = 5 + head[2]
+          else:
+            if (((head[2] << 8) | head[3]) & 0xFFFF) != val:
+              index = 0
+              remain = 0
+            else:
+              index = 8
+        if index > 0:
+          package = [0]*(index + 1)
+          package[1:5] = head
+          remain = index - 4
+          index = 5
+          t = time.time()
+          while remain > 0:
+            if self._ser.inWaiting():
+              data = self._ser.read(1)
+              try: 
+                package[index] = ord(data)
+              except:
+                package[index] = data
+              index += 1
+              remain -= 1
+              t = time.time()
+            if(time.time() - t >self._timeout):
+              print("time out1.")
+              return [self.eRTU_RECV_ERROR]
+          crc = ((package[len(package) - 2] << 8) | package[len(package) - 1]) & 0xFFFF
+          if crc != self._calculate_crc(package[1:len(package) - 2]):
+            print("CRC ERROR")
+            return [self.eRTU_RECV_ERROR]
+          if package[2] & 0x80:
+            package[0] = package[3]
+          else:
+            package[0] = 0
+          #lin = ['%02X' % i for i in package]
+          #print(" ".join(lin))
+          return package
+
+
+

--- a/DFRobot_RTU-master/python/raspberrypi/README.md
+++ b/DFRobot_RTU-master/python/raspberrypi/README.md
@@ -1,0 +1,302 @@
+# DFRobot_RTU
+
+* [中文版](./README_CN.md)
+
+Modbus RTU libary for raspberrypi. The supported modbus commands are as follows：<br>
+* 0x01: Read one or multiple coils register;
+* 0x02: Read one or multiple discrete inputs register;
+* 0x03: Read one or multiple holding register;
+* 0x04: Read one or multiple input register;
+* 0x05: Write a coils register;
+* 0x06: write a holding register;
+* 0x0F: Write multiple coils register;
+* 0x10: Write multiple holding register;
+* support python2 and python3
+
+![正反面svg效果图](https://github.com/Arya11111/DFRobot_MCP23017/blob/master/resources/images/SEN0245svg1.png)
+
+
+## Product Link（链接到英文商城）
+    
+   
+## Table of Contents
+
+* [Summary](#summary)
+* [Connected](#connected)
+* [Installation](#installation)
+* [Calibration](#calibration)
+* [Methods](#methods)
+* [Compatibility](#compatibility)
+* [History](#history)
+* [Credits](#credits)
+
+## Summary
+This is a modbus RTU libary  for Arduino by DFRobot.<br>
+
+## Connected
+Hardware conneted table 
+
+Sensor      |               raspberrypi         
+------------ | :-------------------------------: 
+VCC          |                5V                 
+GND          |                GND                
+RX           |connected to the UART TX pin of MCU
+TX           |connected to the UART RX pin of MCU
+
+## Installation
+To use this library, first download the library file, then open the examples folder and run the demo in the folder Proceed as follows:
+* sudo git clone https://github.com/DFRobot/DFRobot_RTU
+* cd python
+* cd raspberrypi
+* cd examples
+* python demo_*
+* python3 demo_*
+
+
+## Methods
+
+```C++
+'''
+  @brief Serial initialization.
+  @param baud:  The UART baudrate of raspberry pi
+  @param bits:  The UART data bits of raspberry pi
+  @param parity:  The UART parity bits of raspberry pi
+  @param stopbit:  The UART stopbit bits of raspberry pi.
+'''
+def __init__(self, baud, bits, parity, stopbit):
+
+'''
+  @brief Set receive timeout time, unit s.
+  @param timeout:  receive timeout time, unit s, default 0.1s.
+'''
+def set_timout_time_s(self, timeout):
+
+'''
+  @brief Read a coils Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Coils register address.
+  @return Return the value of the coils register value.
+  @n      True: The value of the coils register value is 1.
+  @n      False: The value of the coils register value is 0.
+'''
+def read_coils_register(self, id, reg):
+    
+'''
+  @brief Read a discrete input register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Discrete input register address.
+  @return Return the value of the discrete input register value.
+  @n      True: The value of the discrete input register value is 1.
+  @n      False: The value of the discrete input register value is 0.
+'''
+def read_discrete_inputs_register(self, id, reg):
+
+'''
+  @brief Read a holding Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Holding register address.
+  @return Return the value of the holding register value.
+'''
+def read_holding_register(self, id, reg):
+
+'''
+  @brief Read a input Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Input register address.
+  @return Return the value of the holding register value.
+'''
+def read_input_register(self, id, reg):
+
+'''
+  @brief Write a coils Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Coils register address.
+  @param flag: The value of the register value which will be write, True ro False.
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n      10 or eRTU_MEMORY_ERROR: Memory error.
+  @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+'''
+def write_coils_register(self, id, reg, flag):
+
+'''
+  @brief Write a holding register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Holding register address.
+  @param val: The value of the register value which will be write.
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n      10 or eRTU_MEMORY_ERROR: Memory error.
+  @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+'''
+def write_holding_register(self, id, reg, val):
+
+'''
+  @brief Read multiple coils Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Read the start address of the coil register.
+  @param reg_num: Number of coils Register.
+  @return list: format as follow:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n               10 or eRTU_MEMORY_ERROR: Memory error.
+  @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+  @n      list[1:]: The value of the coil register list.
+'''
+def read_coils_registers(self, id, reg, reg_num):
+
+'''
+  @brief Read multiple discrete inputs register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Read the start address of the discrete inputs register.
+  @param reg_num: Number of coils Register.
+  @return list: format as follow:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n               10 or eRTU_MEMORY_ERROR: Memory error.
+  @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+  @n      list[1:]: The value list of the discrete inputs register.
+'''
+def read_discrete_inputs_registers(self, id, reg, reg_num):
+
+'''
+  @brief Read multiple holding register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Read the start address of the holding register.
+  @param len: Number of read holding register.
+  @return list: format as follow:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n               10 or eRTU_MEMORY_ERROR: Memory error.
+  @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+  @n      list[1:]: The value list of the holding register.
+'''
+def read_holding_registers(self, id, reg, size):
+
+'''
+  @brief Read multiple input register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Read the start address of the input register.
+  @param size: Number of read input register.
+  @return list: format as follow:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n               9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n               10 or eRTU_MEMORY_ERROR: Memory error.
+  @n               11 or eRTU_ID_ERROR: Broadcasr address or error ID
+  @n      list[1:]: The value list of the input register.
+'''
+def read_input_registers(self, id, reg, size):
+    
+'''
+  @brief Write multiple coils Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Write the start address of the coils register.
+  @param reg_num: Number of coils Register.
+  @param data: The list of storage coils Registers' value which will be write.
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n      10 or eRTU_MEMORY_ERROR: Memory error.
+  @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+'''
+def write_coils_registers(self, id, reg, reg_num, data):
+
+'''
+  @brief Write multiple holding Register.
+  @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+  @n          but will not answer.
+  @param reg: Write the start address of the holding register.
+  @param data: The list of storage holding Registers' value which will be write.
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+  @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+  @n      10 or eRTU_MEMORY_ERROR: Memory error.
+  @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+'''
+def write_holding_registers(self, id, reg, data):
+
+```
+
+## Compatibility
+
+MCU                | SoftwareSerial | HardwareSerial |  IO   
+------------------ | :----------: | :----------: | :---------: 
+Arduino Uno        |      √       |      X       |      √       
+Mega2560           |      √       |      √       |      √       
+Leonardo           |      √       |      √       |      √       
+ESP32              |      X       |      √       |      √       
+ESP8266            |      √       |      X       |      √       
+micro:bit          |      X       |      X       |      √       
+FireBeetle M0      |      X       |      √       |      √       
+raspberry          |      X       |      √       |      √       
+
+## History
+
+- Data 2021-07-18
+- Version V1.0
+
+## Credits
+
+Written by(xue.peng@dfrobot.com), 2021. (Welcome to our [website](https://www.dfrobot.com/))
+
+
+
+
+

--- a/DFRobot_RTU-master/python/raspberrypi/README_CN.md
+++ b/DFRobot_RTU-master/python/raspberrypi/README_CN.md
@@ -1,0 +1,265 @@
+# DFRobot_RTU
+
+* [English Version](./README.md)
+
+这是一个基于Modbus RTU协议的raspberry pi python modbus库，它支持以下几种modbus协议命令：<br>
+* 0x01: 读一个或多个线圈寄存器；
+* 0x02: 读一个或多个离散输入寄存器；
+* 0x03: 读一个或多个保持寄存器；
+* 0x04: 读一个或多个输入寄存器；
+* 0x05: 写单个线圈寄存器；
+* 0x06: 写单个保持寄存器；
+* 0x0F: 写多个线圈寄存器；
+* 0x10: 写多个保持寄存器；
+
+![正反面svg效果图](https://github.com/Arya11111/DFRobot_MCP23017/blob/master/resources/images/SEN0245svg1.png)
+
+
+## Product Link（链接到英文商城）
+    
+   
+## Table of Contents
+
+* [Summary](#summary)
+* [Connected](#connected)
+* [Installation](#installation)
+* [Calibration](#calibration)
+* [Methods](#methods)
+* [Compatibility](#compatibility)
+* [History](#history)
+* [Credits](#credits)
+
+## Summary
+这是DFRobot基于modbus RTU协议为raspberry pi 平台移植的python modbus库。<br>
+
+
+## Connected
+Hardware conneted table 
+
+Sensor      |               raspberry pi         |
+------------ | :-------------------------------: |
+VCC          |                5V                 |
+GND          |                GND                |
+RX           |connected to the UART TX pin of MCU|
+TX           |connected to the UART RX pin of MCU|
+
+## Installation
+To use this library, first download the library file, then open the examples folder and run the demo in the folder Proceed as follows:
+* sudo git clone https://github.com/DFRobot/DFRobot_RTU
+* cd python
+* cd raspberrypi
+* cd examples
+* python demo_*
+* python3 demo_*
+
+## Methods
+
+```C++
+'''
+  @brief 树莓派串口通信配置.
+  @param baud:  树莓派串口通信波特率参数
+  @param bits:  树莓派串口通信数据位参数
+  @param parity:  树莓派串口通信校验位参数
+  @param stopbit:  树莓派串口通信停止位参数
+'''
+def __init__(self, baud, bits, parity, stopbit):
+
+'''
+  @brief 设置接收超时时间，单位s.
+  @param timeout:  接收超时形参，单位秒，默认为0.1s
+'''
+def set_timout_time_s(self, timeout = 0.1):
+    
+'''
+  @brief 读取线圈寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 线圈寄存器地址。
+  @return 返回线圈寄存器的值。
+  @n      True: 线圈寄存器的值为1
+  @n      False: 线圈寄存器的值为0
+'''
+def read_coils_register(self, id, reg):
+    
+'''
+  @brief 读取离散输入寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 离散输入寄存器地址。
+  @return 返回离散输入寄存器的值。
+  @n      True: 离散输入寄存器的值为1
+  @n      False: 离散输入寄存器的值为0
+'''
+def read_discrete_inputs_register(self, id, reg):
+
+'''
+  @brief 读取保持寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 保持寄存器地址。
+  @return 返回保持寄存器的值。
+'''
+def read_holding_register(self, id, reg):
+
+'''
+  @brief 读取输入寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 输入寄存器地址。
+  @return 返回输入寄存器的值。
+'''
+def read_input_register(self, id, reg):
+
+'''
+  @brief 写单个线圈寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 线圈寄存器地址。
+  @param flag: 将要被写入的线圈寄存器的值，True or False
+  @return 返回写入的线圈寄存器的值
+'''
+def write_coils_register(self, id, reg, flag):
+
+'''
+  @brief 写单个保持寄存器的值。
+  @param id:   modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 保持寄存器地址。
+  @param val: 将要被写入的保持寄存器的值
+  @return 返回写入的保持寄存器的值
+'''
+def write_holding_register(self, id, reg, val):
+
+'''
+  @brief 读取多个线圈寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 读取线圈寄存器的起始地址。
+  @param reg_num: 离散输入寄存器的个数
+  @return 列表: 格式如下:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n               9 or eRTU_RECV_ERROR:  接收包错误.
+  @n               10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n               11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+  @n      list[1:]: 读取的线圈寄存器的值.
+'''
+def read_coils_registers(self, id, reg, reg_num):
+
+'''
+  @brief 读取多个离散输入寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 读取离散输入寄存器的起始地址。
+  @param reg_num: 离散输入寄存器的个数
+  @return 列表: 格式如下:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n               9 or eRTU_RECV_ERROR:  接收包错误.
+  @n               10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n               11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+  @n      list[1:]: 读取的离散输入寄存器的值.
+'''
+def read_discrete_inputs_registers(self, id, reg, reg_num):
+
+'''
+  @brief 读取多个保持寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 读取保持寄存器的起始地址。
+  @param len: 读取保持寄存器的个数
+  @return 列表: 格式如下:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n               9 or eRTU_RECV_ERROR:  接收包错误.
+  @n               10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n               11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+  @n      list[1:]: 读取的保持寄存器的值.
+'''
+def read_holding_registers(self, id, reg, size):
+
+'''
+  @brief 读取多个输入寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 读取输入寄存器的起始地址。
+  @param len: 读取输入寄存器的个数
+  @return 列表: 格式如下:
+  @n      list[0]: Exception code:
+  @n               0 : sucess.
+  @n               1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n               2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n               3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n               4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n               8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n               9 or eRTU_RECV_ERROR:  接收包错误.
+  @n               10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n               11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+  @n      list[1:]: 读取的输入寄存器的值.
+'''
+def read_input_registers(self, id, reg, size):
+
+'''
+  @brief 写多个线圈寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 写线圈寄存器的起始地址。
+  @param reg_num: 线圈寄存器的个数.
+  @param data: 将要被写入的线圈寄存器的列表
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n      9 or eRTU_RECV_ERROR:  接收包错误.
+  @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+'''
+def write_coils_registers(self, id, reg, reg_num, data):
+
+'''
+  @brief 写多个保持寄存器的值。
+  @param id:  modbus 设备ID，范围0~0xF7(0~247)，其中0x00为广播地址，所有modbus从机都会处理广播包，但不会应答。
+  @param reg: 写保持寄存器的起始地址。
+  @param data: 将要被写入的保持寄存器的列表
+  @return Exception code:
+  @n      0 : sucess.
+  @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : 非法功能.
+  @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: 非法数据地址.
+  @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  非法数据值.
+  @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  从机故障.
+  @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC校验错误.
+  @n      9 or eRTU_RECV_ERROR:  接收包错误.
+  @n      10 or eRTU_MEMORY_ERROR: 内存错误.
+  @n      11 or eRTU_ID_ERROR:广播地址或错误ID(因为主机无法收到从机广播包的应答)
+'''
+def write_holding_registers(self, id, reg, data):
+```
+
+## Compatibility
+
+MCU                | SoftwareSerial | HardwareSerial |
+------------------ | :----------: | :----------: |
+Arduino Uno        |      √       |      X       |
+Mega2560           |      √       |      √       |
+Leonardo           |      √       |      √       |
+ESP32              |      X       |      √       |
+ESP8266            |      √       |      X       |
+micro:bit          |      X       |      X       |
+FireBeetle M0      |      X       |      √       |
+raspberry          |      X       |      √       |
+
+## History
+
+- Data 2021-07-17
+- Version V1.0
+
+## Credits
+
+Written by(xue.peng@dfrobot.com), 2021. (Welcome to our [website](https://www.dfrobot.com/))

--- a/DFRobot_RTU-master/python/raspberrypi/examples/modify_modbus_id.py
+++ b/DFRobot_RTU-master/python/raspberrypi/examples/modify_modbus_id.py
@@ -1,0 +1,50 @@
+# -*- coding:utf-8 -*-
+
+'''
+  # modify_modbus_id.py
+  #
+  # @brief 修改modbus从机的设备ID。每个modbus从机都有唯一识别的设备ID号，范围0x0000~0x00F7(0~247),修改设备ID有2种方式：
+  # @n 1: 不知道设备的ID地址，可以通过广播地址0x00修改从机的ID地址，此命令会将总线上所有的从机的地址都修改为设置的ID（用0x00修改地址时，总线上最好只接一个设备）
+  # @n 2: 知道设备的ID地址，直接用ID修改
+  # @n note：运行此demo必须知道设备的串口配置(波特率，数据位，校验位，停止位)
+  #
+  # @n connected
+  # -----------------------------------------------------------------------------
+  # sensor pin |             MCU                |         raspberry pi          |
+  #     VCC    |            3.3V/5V             |            5V/3V3             |
+  #     GND    |              GND               |             GND               |
+  #     RX     |              TX                |          (BCM)14 TX           |
+  #     TX     |              RX                |          (BCM)15 RX           |
+  # -----------------------------------------------------------------------------
+  #
+  # @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+  # @licence     The MIT License (MIT)
+  # @author [Arya](xue.peng@dfrobot.com)
+  # @version  V1.0
+  # @date  2021-07-16
+  # @https://github.com/DFRobot/DFRobot_RTU
+'''
+
+import sys
+import os
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from DFRobot_RTU import *
+
+modbus = DFRobot_RTU(9600, 8, 'N', 1)
+
+if __name__ == "__main__":
+  DEVICE_ID_REG = 0x02
+  '''方法1：通过广播地址0x00将modbus从机的地址设置为0x10'''
+  modbus.write_holding_register(id = 0x00, reg = DEVICE_ID_REG, val = 0x10)
+  time.sleep(1)
+  ret = modbus.read_holding_register(id = 0x10, reg = DEVICE_ID_REG)
+  if ret == 0x10:
+    print("new ID1 is %02X"%ret)
+    '''方法2：已知从机的地址为0x10，将其修改为0x20'''
+    modbus.write_holding_register(id = 0x10, reg = DEVICE_ID_REG, val = 0x20)
+    time.sleep(1)
+    ret = modbus.read_holding_register(id = 0x20, reg = DEVICE_ID_REG)
+    print("new ID2 is %02X"%ret)
+

--- a/DFRobot_RTU-master/python/raspberrypi/examples/scan_modbus_id.py
+++ b/DFRobot_RTU-master/python/raspberrypi/examples/scan_modbus_id.py
@@ -1,0 +1,52 @@
+# -*- coding:utf-8 -*-
+
+'''
+  # scan_modbus_id.py
+  #
+  # @brief 扫描modbus总线上，所有串口配置为9600波特率，8位数据位，无校验位，1位停止位的modbus从机的地址。
+  # @n modbus从机设备地址范围为1~247(0x01~0xF7),0为广播地址，所有modbus从机接受到广播包都会处理，但不会响应。
+  # @n 一个modbus主机可以连多个modbus从机，在运行此demo之前，必须知道modbus从机的波特率，数据位，校验位，停止位等串口配置。
+  #
+  # @n connected
+  # -----------------------------------------------------------------------------
+  # sensor pin |             MCU                |         raspberry pi          |
+  #     VCC    |            3.3V/5V             |            5V/3V3             |
+  #     GND    |              GND               |             GND               |
+  #     RX     |              TX                |          (BCM)14 TX           |
+  #     TX     |              RX                |          (BCM)15 RX           |
+  # -----------------------------------------------------------------------------
+  #
+  # @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+  # @licence     The MIT License (MIT)
+  # @author [Arya](xue.peng@dfrobot.com)
+  # @version  V1.0
+  # @date  2021-07-16
+  # @https://github.com/DFRobot/DFRobot_RTU
+'''
+
+import sys
+import os
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from DFRobot_RTU import *
+
+modbus = DFRobot_RTU(9600, 8, 'N', 1)
+
+if __name__ == "__main__":
+  DEVICE_ID_REG = 0x02
+  while True:
+    modbus_id = 1
+    n_devices = 0
+    print("Scanning...")
+    while modbus_id < 248:
+      ret = modbus.read_holding_register(modbus_id, DEVICE_ID_REG)
+      if ret == modbus_id:
+        print("modbus device found at address 0x%02X !"%modbus_id)
+        n_devices += 1
+      modbus_id += 1
+    if n_devices == 0:
+      print("No modbus devices found\n")
+    else:
+      print("done\n")
+    time.sleep(1)

--- a/DFRobot_RTU-master/python/raspberrypi/examples/test.py
+++ b/DFRobot_RTU-master/python/raspberrypi/examples/test.py
@@ -1,0 +1,59 @@
+# -*- coding:utf-8 -*-
+
+'''
+  # test.py
+  #
+  # @brief 测试发送命令
+  #
+  # @n connected
+  # -----------------------------------------------------------------------------
+  # sensor pin |             MCU                |         raspberry pi          |
+  #     VCC    |            3.3V/5V             |            5V/3V3             |
+  #     GND    |              GND               |             GND               |
+  #     RX     |              TX                |          (BCM)14 TX           |
+  #     TX     |              RX                |          (BCM)15 RX           |
+  # -----------------------------------------------------------------------------
+  #
+  # @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+  # @licence     The MIT License (MIT)
+  # @author [Arya](xue.peng@dfrobot.com)
+  # @version  V1.0
+  # @date  2021-07-16
+  # @https://github.com/DFRobot/DFRobot_RTU
+'''
+
+import sys
+import os
+import time
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from DFRobot_RTU import *
+
+modbus = DFRobot_RTU(9600, 8, 'N', 1)
+
+if __name__ == "__main__":
+  DEVICE_ID_REG = 0x02
+  while True:
+    print("read_coils_register:")
+    modbus.read_coils_register(id = 0x20, reg = 0x00)
+    print("read_discrete_inputs_register:")
+    modbus.read_discrete_inputs_register(id = 0x20, reg = 0x00)
+    print("read_discrete_inputs_register:")
+    modbus.read_discrete_inputs_register(id = 0x20, reg = 0x00)
+    print("read_coils_registers:")
+    modbus.read_coils_registers(id = 0x20, reg = 0x00, reg_num = 1)
+    print("read_discrete_inputs_registers:")
+    modbus.read_discrete_inputs_registers(id = 0x20, reg = 0x00, reg_num = 1)
+    print("read_holding_registers:")
+    modbus.read_holding_registers(id = 0x20, reg = 0x00, size = 1)
+    print("write_coils_registers:")
+    modbus.write_coils_registers(id = 0x20, reg = 0x02, reg_num = 1, data = [0xFF])
+    print("write_holding_registers:")
+    modbus.write_holding_registers(id = 0x20, reg = 0x02, data = [0x00,0x20])
+    print("write_coils_register:")
+    modbus.write_coils_register(id = 0x20, reg = 0x02, flag = True)
+    print("write_holding_register:")
+    modbus.write_holding_register(id = 0x20, reg = 0x02, val = 0x20)
+
+    print("\n")
+    time.sleep(2)

--- a/DFRobot_RTU-master/src/DFRobot_RTU.cpp
+++ b/DFRobot_RTU-master/src/DFRobot_RTU.cpp
@@ -1,0 +1,549 @@
+/*!
+ * @file DFRobot_RTU.cpp
+ * @brief Modbus RTU libary for Arduino. 
+ *
+ * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+ * @licence     The MIT License (MIT)
+ * @author [Arya](xue.peng@dfrobot.com)
+ * @version  V1.0
+ * @date  2021-07-16
+ * @https://github.com/DFRobot/DFRobot_RTU
+ */
+#include <Arduino.h>
+#include "DFRobot_RTU.h"
+
+DFRobot_RTU::DFRobot_RTU(Stream *s,int dePin)
+  :_timeout(100), _s(s),_dePin(dePin){
+  if(_dePin>0){
+    pinMode(_dePin,OUTPUT);
+  }
+}
+
+DFRobot_RTU::DFRobot_RTU(Stream *s)
+  :_timeout(100), _s(s),_dePin(-1){
+  if(_dePin>0){
+    pinMode(_dePin,OUTPUT);
+  }
+}
+
+DFRobot_RTU::DFRobot_RTU()
+  : _timeout(100), _s(NULL),_dePin(-1){
+  if(_dePin>0){
+    pinMode(_dePin,OUTPUT);
+  }
+}
+
+void DFRobot_RTU::setTimeoutTimeMs(uint32_t timeout){
+  _timeout = timeout;
+}
+
+bool DFRobot_RTU::readCoilsRegister(uint8_t id, uint16_t reg){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), 0x00, 0x01};
+  bool val = false;
+  uint8_t *pData = NULL;
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_COILS, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_COILS, 1, &ret);
+  if((ret == 0) && (header != NULL)){
+    pData = header->payload;
+    if (pData[1] & 0x01) val = true;
+  }
+  RTU_DBG(val, HEX);
+  return val;
+}
+
+bool DFRobot_RTU::readDiscreteInputsRegister(uint8_t id, uint16_t reg){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), 0x00, 0x01};
+  uint8_t *pData = NULL;
+  bool val = false;
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_DISCRETE, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_DISCRETE, 1, &ret);
+  if((ret == 0) && (header != NULL)){
+    pData = header->payload;
+    if (pData[1] & 0x01) val = true;
+    free(header);
+  }
+  RTU_DBG(val, HEX);
+  return val;
+}
+
+uint16_t DFRobot_RTU::readHoldingRegister(uint8_t id, uint16_t reg){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), 0x00, 0x01};
+  uint16_t val = 0;
+  uint8_t *pData = NULL;
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_HOLDING, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_HOLDING, 2, &ret);
+  if((ret == 0) && (header != NULL)){
+    pData = header->payload;
+    val = (pData[1] << 8) | pData[2];
+    free(header);
+  }
+  //RTU_DBG(val, HEX);
+  return val;
+}
+
+uint16_t DFRobot_RTU::readInputRegister(uint8_t id, uint16_t reg){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), 0x00, 0x01};
+  uint16_t val = 0;
+  uint8_t *pData = NULL;
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_INPUT, temp, sizeof(temp));
+  RTU_DBG(header->len,HEX);
+  RTU_DBG(header->id,HEX);
+  RTU_DBG(header->cmd,HEX);
+  for(uint8_t i=0;i<sizeof(temp)+2;i++)
+  RTU_DBG(((uint8_t *)header->payload)[i],HEX);
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_INPUT, 2, &ret);
+  if((ret == 0) && (header != NULL)){
+    pData = header->payload;
+    val = (pData[1] << 8) | pData[2];
+    free(header);
+  }
+  RTU_DBG(val, HEX);
+  return val;
+}
+
+uint8_t DFRobot_RTU::writeCoilsRegister(uint8_t id, uint16_t reg, bool flag){
+  uint16_t val = flag ? 0xFF00 : 0x0000;
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((val >> 8) & 0xFF), (uint8_t)(val & 0xFF)};
+  uint8_t ret = 0;
+  if(id > 0xF7){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_WRITE_COILS, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_WRITE_COILS, reg, &ret);
+  if((ret == 0) && (header != NULL)){
+      free(header);
+  }
+  return ret;
+}
+uint8_t DFRobot_RTU::writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t val){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((val >> 8) & 0xFF), (uint8_t)(val & 0xFF)};
+  uint8_t ret = 0;
+  if(id > 0xF7){
+    RTU_DBG("Device id error");
+    return 0;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_WRITE_HOLDING, temp, sizeof(temp));
+  //uint8_t *data = (uint8_t *)header;
+  //for (int i = 0; i < sizeof(sRtuPacketHeader_t); i++){
+  //  if (data != NULL) RTU_DBG(*data, HEX);
+  //  data++;
+  //}
+  
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_WRITE_HOLDING, reg, &ret);
+  val = 0xFFFF;
+  if((ret == 0) && (header != NULL)){
+      val = (((uint8_t *)header->payload)[2] << 8) | ((uint8_t *)header->payload)[3];
+      free(header);
+  }
+  //RTU_DBG(val, HEX);
+  return ret;
+}
+
+uint8_t DFRobot_RTU::readCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size){
+  uint8_t length = regNum/8 + ((regNum%8) ? 1 : 0);
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((regNum >> 8) & 0xFF), (uint8_t)(regNum & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_COILS, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_COILS, length, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL){
+      size = (size > length) ? length : size;
+      memcpy(data, (uint8_t *)&(header->payload[1]), size);
+    } 
+    free(header);
+  }
+  return ret;
+}
+uint8_t DFRobot_RTU::readDiscreteInputsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size){
+  uint8_t length = regNum/8 + ((regNum%8) ? 1 : 0);
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((regNum >> 8) & 0xFF), (uint8_t)(regNum & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_DISCRETE, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_DISCRETE, length, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL){
+      size = (size > length) ? length : size;
+      memcpy(data, (uint8_t *)&(header->payload[1]), size);
+    } 
+    free(header);
+  }
+  return ret;
+}
+uint8_t DFRobot_RTU::readHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size){
+  uint8_t length = size/2 + ((size%2) ? 1 : 0);
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((length >> 8) & 0xFF), (uint8_t)(length & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_HOLDING, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_HOLDING, length*2, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL) memcpy(data, (uint8_t *)&(header->payload[1]), size);
+    free(header);
+  }
+  return ret;
+}
+
+uint8_t DFRobot_RTU::readInputRegister(uint8_t id, uint16_t reg, void *data, uint16_t size){
+  uint8_t length = size/2 + ((size%2) ? 1 : 0);
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((length >> 8) & 0xFF), (uint8_t)(length & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_INPUT, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_INPUT, length*2, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL) memcpy(data, (uint8_t *)&(header->payload[1]), size);
+    free(header);
+  }
+  RTU_DBG(val, HEX);
+  return ret;
+}
+
+uint8_t DFRobot_RTU::readHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((regNum >> 8) & 0xFF), (uint8_t)(regNum & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_HOLDING, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_HOLDING, regNum*2, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL){
+      for(int i = 0; i < regNum; i++){
+        data[i] = ((((uint8_t *)header->payload)[1+2*i]) << 8) | (((uint8_t *)header->payload)[2+2*i]);
+      }
+    } 
+    free(header);
+  }
+  return ret;
+}
+
+uint8_t DFRobot_RTU::readInputRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum){
+  uint8_t temp[] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)((regNum >> 8) & 0xFF), (uint8_t)(regNum & 0xFF)};
+  uint8_t ret = 0;
+  if((id == 0) && (id > 0xF7)){
+    RTU_DBG("Device id error");
+    return eRTU_ID_ERROR;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_READ_INPUT, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_READ_INPUT, regNum*2, &ret);
+  if((ret == 0) && (header != NULL)){
+    if(data != NULL){
+      for(int i = 0; i < regNum; i++){
+        data[i] = ((((uint8_t *)header->payload)[1+2*i]) << 8) | (((uint8_t *)header->payload)[2+2*i]);
+      }
+    } 
+    free(header);
+  }
+  return ret;
+}
+
+uint8_t DFRobot_RTU::writeCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size){
+  uint16_t length = regNum/8 + ((regNum%8) ? 1 : 0);
+  if(size < length) return (uint8_t)eRTU_EXCEPTION_ILLEGAL_DATA_VALUE;
+  //#if defined(ESP8266)
+  uint8_t temp[size + 5];
+  temp[0] = (uint8_t)((reg >> 8) & 0xFF);
+  temp[1] = (uint8_t)(reg & 0xFF);
+  temp[2] = (uint8_t)((regNum >> 8) & 0xFF);
+  temp[3] = (uint8_t)(regNum & 0xFF);
+  temp[4] = (uint8_t)length;
+  //#else
+  //uint8_t temp[size + 5] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF),(uint8_t)((regNum >> 8) & 0xFF), (uint8_t)(regNum & 0xFF),(uint8_t)length};
+  //#endif
+  uint8_t ret = 0;
+  if(id > 0xF7){
+    RTU_DBG("Device id error");
+    return (uint8_t)eRTU_ID_ERROR;
+  }
+  memcpy(temp+5, data, size);
+  pRtuPacketHeader_t header = packed(id, eCMD_WRITE_MULTI_COILS, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_WRITE_MULTI_COILS, reg, &ret);
+  size = 0;
+  if((ret == 0) && (header != NULL)){
+    size = (((uint8_t *)header->payload)[2] << 8) | ((uint8_t *)header->payload)[3];
+    free(header);
+  }
+  return ret;
+}
+uint8_t DFRobot_RTU::writeHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size){
+  if(((size % 2) != 0) || (size > 250) || data == NULL) return (uint8_t)eRTU_EXCEPTION_ILLEGAL_DATA_VALUE;
+  //#if defined(ESP8266)
+  uint8_t temp[size + 5];
+  temp[0] = (uint8_t)((reg >> 8) & 0xFF);
+  temp[1] = (uint8_t)(reg & 0xFF);
+  temp[2] = (uint8_t)(((size/2) >> 8) & 0xFF);
+  temp[3] = (uint8_t)((size/2) & 0xFF);
+  temp[4] = (uint8_t)size;
+  //#else
+  //uint8_t temp[size + 5] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)(((size/2) >> 8) & 0xFF), (uint8_t)((size/2) & 0xFF),(uint8_t)size};
+  //#endif
+  uint8_t ret = 0;
+  if(id > 0xF7){
+    RTU_DBG("Device id error");
+    return (uint8_t)eRTU_ID_ERROR;
+  }
+  memcpy(temp+5, data, size);
+  pRtuPacketHeader_t header = packed(id, eCMD_WRITE_MULTI_HOLDING, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_WRITE_MULTI_HOLDING, reg, &ret);
+  size = 0;
+  if((ret == 0) && (header != NULL)){
+    size = (((uint8_t *)header->payload)[2] << 8) | ((uint8_t *)header->payload)[3];
+    free(header);
+  }
+  return ret;
+}
+
+uint8_t DFRobot_RTU::writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum){
+  uint16_t size = regNum * 2;
+  uint8_t *pBuf = (uint8_t *)data;
+  //#if defined(ESP8266)
+  uint8_t temp[size + 5];
+  temp[0] = (uint8_t)((reg >> 8) & 0xFF);
+  temp[1] = (uint8_t)(reg & 0xFF);
+  temp[2] = (uint8_t)(((size/2) >> 8) & 0xFF);
+  temp[3] = (uint8_t)((size/2) & 0xFF);
+  temp[4] = (uint8_t)size;
+  //#else
+  //uint8_t temp[size + 5] = {(uint8_t)((reg >> 8) & 0xFF), (uint8_t)(reg & 0xFF), (uint8_t)(((size/2) >> 8) & 0xFF), (uint8_t)((size/2) & 0xFF),(uint8_t)size};
+  //#endif
+  uint8_t ret = 0;
+  if(id > 0xF7){
+    RTU_DBG("Device id error");
+    return (uint8_t)eRTU_ID_ERROR;
+  }
+  //memcpy(temp+5, data, size);
+  for(int i = 0; i < regNum; i++){
+    temp[5+i*2] =  pBuf[2*i + 1];
+    temp[6+i*2] =  pBuf[2*i] ;
+  }
+  pRtuPacketHeader_t header = packed(id, eCMD_WRITE_MULTI_HOLDING, temp, sizeof(temp));
+  sendPackage(header);
+  header = recvAndParsePackage(id, (uint8_t)eCMD_WRITE_MULTI_HOLDING, reg, &ret);
+  size = 0;
+  if((ret == 0) && (header != NULL)){
+    size = (((uint8_t *)header->payload)[2] << 8) | ((uint8_t *)header->payload)[3];
+    free(header);
+  }
+  return ret;
+}
+
+DFRobot_RTU::pRtuPacketHeader_t DFRobot_RTU::packed(uint8_t id, eFunctionCommand_t cmd, void *data, uint16_t size){
+  return packed(id, (uint8_t)cmd, data, size);
+}
+
+DFRobot_RTU::pRtuPacketHeader_t DFRobot_RTU::packed(uint8_t id, uint8_t cmd, void *data, uint16_t size){
+  pRtuPacketHeader_t header = NULL;
+  uint16_t crc = 0;
+  if((data == NULL) || (size == 0)) return NULL;
+  if((header = (pRtuPacketHeader_t)malloc(sizeof(sRtuPacketHeader_t) + size)) == NULL){
+    RTU_DBG("Memory ERROR");
+    return NULL;
+  }
+  header->len = sizeof(sRtuPacketHeader_t) + size - 2;
+  header->id = id;
+  header->cmd = cmd;
+  memcpy(header->payload, data, size);
+  crc = calculateCRC((uint8_t *)&(header->id), (header->len) - 2);
+  ((uint8_t *)header->payload)[size] = (crc >> 8) & 0xFF;
+  ((uint8_t *)header->payload)[size+1] = crc & 0xFF;
+  return header;
+}
+
+void DFRobot_RTU::sendPackage(pRtuPacketHeader_t header){
+  clearRecvBuffer();
+  if(header != NULL){
+    if(_dePin>0){
+      digitalWrite(_dePin,HIGH);
+      delayMicroseconds(50);
+    }
+    _s->write((uint8_t *)&(header->id), header->len);
+    _s->flush();
+    
+    free(header);
+    if(_dePin>0){
+      //delayMicroseconds(50);
+      digitalWrite(_dePin,LOW);
+    }
+  }
+}
+
+DFRobot_RTU::pRtuPacketHeader_t DFRobot_RTU::recvAndParsePackage(uint8_t id, uint8_t cmd, uint16_t data, uint8_t *error){
+  if(id > 0xF7) return NULL;
+  if(id == 0){
+    if (error != NULL) *error = 0;
+    return NULL;
+  }
+  
+  uint8_t head[4] = {0, 0, 0, 0};
+  uint16_t crc = 0;
+  pRtuPacketHeader_t header = NULL;
+  //uint8_t timeInterMs = 5;
+
+LOOP:
+  uint16_t remain, index = 0;
+  uint32_t time = millis();
+  for(int i = 0; i < 4;){
+    if(_s->available()){
+      head[index++] = (uint8_t)_s->read();
+      RTU_DBG(head[index-1],HEX);
+      if((index == 1) && (head[0] != id)){
+        index = 0;
+      }else if((index == 2) && ((head[1]&0x7F) != cmd)){
+        index = 0;
+      }
+      i = index;
+      time = millis();
+    }
+    if((millis() - time) > _timeout) {
+      RTU_DBG("ERROR");
+      RTU_DBG(millis() - time);
+      break;
+    }
+  }
+
+  if(index != 4) {
+    RTU_DBG();
+    if(error != NULL) *error = eRTU_RECV_ERROR;
+    return NULL;
+  }
+  switch(head[1]){
+    case eCMD_READ_COILS:
+    case eCMD_READ_DISCRETE:
+    case eCMD_READ_HOLDING:
+    case eCMD_READ_INPUT:
+      if(head[2] != (data & 0xFF)) {
+        index = 0;
+        goto LOOP;
+      }
+      index = 5 + head[2];
+      break;
+    case eCMD_WRITE_COILS:
+    case eCMD_WRITE_HOLDING:
+    case eCMD_WRITE_MULTI_COILS:
+    case eCMD_WRITE_MULTI_HOLDING:
+      if(((head[2] << 8) | (head[3])) != data){
+        index = 0;
+        goto LOOP;
+      }
+      index = 8;
+      break;
+    default:
+      index = 5;
+      break;
+  }
+  if((header = (pRtuPacketHeader_t)malloc(index+2)) == NULL){
+    RTU_DBG("Memory ERROR");
+    if(error != NULL) *error = eRTU_RECV_ERROR;
+    return NULL;
+  }
+  header->len = index;
+  memcpy((uint8_t *)&(header->id), head, 4);
+  remain = index - 4;
+  index = 2;
+  time = millis();
+  while(remain){
+    RTU_DBG(_s->available());
+    if(_s->available()){
+      *(header->payload+index) = (uint8_t)_s->read();
+      index++;
+      time = millis();
+      remain--;
+    }
+    if((millis() - time) > _timeout) {
+      free(header);
+      if(error != NULL) *error = eRTU_RECV_ERROR;
+      RTU_DBG();
+      return NULL;
+    }
+  }
+  crc = (((uint8_t *)header->payload)[(header->len)-4] << 8) | ((uint8_t *)header->payload)[(header->len)-3];
+
+  if(crc != calculateCRC((uint8_t *)&(header->id), (header->len) - 2)){
+    free(header);
+    RTU_DBG("CRC ERROR");
+    if(error != NULL) *error = eRTU_RECV_ERROR;
+    return NULL;
+  }
+  if(error != NULL) *error = 0;
+  if(head[1] & 0x80){
+    *error = head[2];
+  }
+  
+  return header;
+
+}
+
+
+uint16_t DFRobot_RTU::calculateCRC(uint8_t *data, uint8_t len){
+  uint16_t crc = 0xFFFF;
+  for( uint8_t pos = 0; pos < len; pos++){
+    crc ^= (uint16_t)data[ pos ];
+    for(uint8_t i = 8; i != 0; i--){
+      if((crc & 0x0001) != 0){
+        crc >>= 1;
+        crc ^= 0xA001;
+      }else{
+         crc >>= 1;
+      }
+    }
+  }
+  crc = ((crc & 0x00FF) << 8) | ((crc & 0xFF00) >> 8);
+  return crc;
+}
+
+void DFRobot_RTU::clearRecvBuffer(){
+  while(_s->available()){
+    _s->read();
+    delay(2);
+  }
+}

--- a/DFRobot_RTU-master/src/DFRobot_RTU.h
+++ b/DFRobot_RTU-master/src/DFRobot_RTU.h
@@ -1,0 +1,347 @@
+/*!
+ * @file DFRobot_RTU.h
+ * @brief Modbus RTU libary for Arduino. 
+ *
+ * @copyright   Copyright (c) 2010 DFRobot Co.Ltd (http://www.dfrobot.com)
+ * @licence     The MIT License (MIT)
+ * @author [Arya](xue.peng@dfrobot.com)
+ * @version  V1.0
+ * @date  2021-07-16
+ * @https://github.com/DFRobot/DFRobot_RTU
+ */
+#ifndef __DFRobot_RTU_H
+#define __DFRobot_RTU_H
+
+#if ARDUINO >= 100
+#include "Arduino.h"
+#else
+#include "WProgram.h"
+#endif
+
+#include<Stream.h>
+
+//Define RTU_DBG, change 0 to 1 open the RTU_DBG, 1 to 0 to close.  
+#if 0
+#define RTU_DBG(...) {Serial.print("["); Serial.print(__FUNCTION__); Serial.print("(): "); Serial.print(__LINE__); Serial.print(" ] "); Serial.println(__VA_ARGS__);}
+#else
+#define RTU_DBG(...)
+#endif
+
+
+#ifndef RTU_BROADCAST_ADDRESS
+#define RTU_BROADCAST_ADDRESS                      0x00 /**<modbus RTU协议的广播地址为0x00*/
+#endif
+
+class DFRobot_RTU{
+protected:
+typedef struct{
+  uint16_t len;
+  uint8_t id;
+  uint8_t cmd;
+  uint8_t payload[0];
+  uint16_t cs;
+}__attribute__ ((packed)) sRtuPacketHeader_t, *pRtuPacketHeader_t;
+
+typedef enum{
+  eRTU_EXCEPTION_ILLEGAL_FUNCTION = 0x01,
+  eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS,
+  eRTU_EXCEPTION_ILLEGAL_DATA_VALUE,
+  eRTU_EXCEPTION_SLAVE_FAILURE,
+  eRTU_EXCEPTION_CRC_ERROR = 0x08,
+  eRTU_RECV_ERROR,
+  eRTU_MEMORY_ERROR,
+  eRTU_ID_ERROR
+}eRtuStatusExceptionCode_t;
+
+typedef enum{
+  eCMD_READ_COILS = 0x01,
+  eCMD_READ_DISCRETE = 0x02,
+  eCMD_READ_HOLDING  = 0x03,
+  eCMD_READ_INPUT  = 0x04,
+  eCMD_WRITE_COILS = 0x05,
+  eCMD_WRITE_HOLDING  = 0x06,
+  eCMD_WRITE_MULTI_COILS = 0x0F,
+  eCMD_WRITE_MULTI_HOLDING  = 0x10
+}eFunctionCommand_t;
+
+  void clearRecvBuffer();
+  uint16_t calculateCRC(uint8_t *data, uint8_t len);
+  pRtuPacketHeader_t packed(uint8_t id, eFunctionCommand_t cmd, void *data, uint16_t size);
+  pRtuPacketHeader_t packed(uint8_t id, uint8_t cmd, void *data, uint16_t size);
+  void sendPackage(pRtuPacketHeader_t header);
+  pRtuPacketHeader_t recvAndParsePackage(uint8_t id, uint8_t cmd, uint16_t data, uint8_t *error);
+public:
+/**
+ * @brief DFRobot_RTU abstract class constructor. Construct serial port.
+ * @param s:  The class pointer object of Abstract class， here you can fill in the pointer to the serial port object.
+ * @param dePin: RS485 flow control, pull low to receive, pull high to send.
+ */
+  DFRobot_RTU(Stream *s,int dePin);
+  DFRobot_RTU(Stream *s);
+  DFRobot_RTU();
+  ~DFRobot_RTU(){}
+
+/**
+ * @brief Set receive timeout time, unit ms.
+ * @param timeout:  receive timeout time, unit ms, default 100mss.
+ */
+  void setTimeoutTimeMs(uint32_t timeout = 100);
+
+/**
+ * @brief Read a coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @return Return the value of the coils register value.
+ * @n      true: The value of the coils register value is 1.
+ * @n      false: The value of the coils register value is 0.
+ */
+  bool readCoilsRegister(uint8_t id, uint16_t reg);
+/**
+ * @brief Read a discrete input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @return Return the value of the coils register value.
+ * @n      true: The value of the coils register value is 1.
+ * @n      false: The value of the coils register value is 0.
+ */
+  bool readDiscreteInputsRegister(uint8_t id, uint16_t reg);
+/**
+ * @brief Read a holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @return Return the value of the holding register value.
+ */
+  uint16_t readHoldingRegister(uint8_t id, uint16_t reg);
+
+/**
+ * @brief Read a input Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: input register address.
+ * @return Return the value of the input register value.
+ */
+  uint16_t readInputRegister(uint8_t id, uint16_t reg);
+/**
+ * @brief Write a coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param flag: The value of the register value which will be write, 0 ro 1.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, bool flag);
+/**
+ * @brief Write a holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @param val: The value of the register value which will be write.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t val);
+
+/**
+ * @brief Read multiple coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param regNum: Number of coils Register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size of data.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+/**
+ * @brief Read multiple discrete inputs register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Discrete inputs register. address.
+ * @param regNum: Number of coils Register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size of data.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readDiscreteInputsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+/**
+ * @brief Read multiple Holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+
+/**
+ * @brief Read multiple Input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Input register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readInputRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+/**
+ * @brief Read multiple Holding register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+
+/**
+ * @brief Read multiple Input register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Input register.
+ * @param data: Storage register worth pointer.
+ * @param regNum: register numbers.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t readInputRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+  
+/**
+ * @brief Write multiple coils Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Coils register address.
+ * @param regNum: Numbers of Coils register.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeCoilsRegister(uint8_t id, uint16_t reg, uint16_t regNum, uint8_t *data, uint16_t size);
+/**
+ * @brief Write multiple Holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @param data: Storage register worth pointer.
+ * @param size: Cache size.
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, void *data, uint16_t size);
+/**
+ * @brief Write multiple Holding Register.
+ * @param id:  modbus device ID. Range: 0x00 ~ 0xF7(0~247), 0x00 is broadcasr address, which all slaves will process broadcast packets, 
+ * @n          but will not answer.
+ * @param reg: Holding register address.
+ * @param data: Storage register worth pointer.
+ * @param regNum: Number of coils Register..
+ * @return Exception code:
+ * @n      0 : sucess.
+ * @n      1 or eRTU_EXCEPTION_ILLEGAL_FUNCTION : Illegal function.
+ * @n      2 or eRTU_EXCEPTION_ILLEGAL_DATA_ADDRESS: Illegal data address.
+ * @n      3 or eRTU_EXCEPTION_ILLEGAL_DATA_VALUE:  Illegal data value.
+ * @n      4 or eRTU_EXCEPTION_SLAVE_FAILURE:  Slave failure.
+ * @n      8 or eRTU_EXCEPTION_CRC_ERROR:  CRC check error.
+ * @n      9 or eRTU_RECV_ERROR:  Receive packet error.
+ * @n      10 or eRTU_MEMORY_ERROR: Memory error.
+ * @n      11 or eRTU_ID_ERROR: Broadcasr address or error ID
+ */
+  uint8_t writeHoldingRegister(uint8_t id, uint16_t reg, uint16_t *data, uint16_t regNum);
+
+  
+private:
+  uint32_t _timeout;
+  Stream *_s;
+  int _dePin;
+};
+#endif


### PR DESCRIPTION
This PR adds the `DFRobot_RTU` library, which is a missing dependency of `DFRobot_LTR390UV`.  
Without this library, the code does not compile because `DFRobot_LTR390UV.h` includes `DFRobot_RTU.h` (line 16).  
The absence of this dependency results in the following compilation error:  

fatal error: DFRobot_RTU.h: No such file or directory
